### PR TITLE
Fix cran removal

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^pkgdown$
 ^CRAN-SUBMISSION$
 ^LICENSE\.md$
+.github

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,14 +37,11 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
 Imports: 
     dplyr,
-    generics,
     glue,
     rlang,
     tidyselect,
     vctrs,
     purrr,
-    magrittr,
-    lifecycle,
     tibble,
     tidyr,
     cli,


### PR DESCRIPTION
https://cran.r-project.org/package=powerjoin

Package appears to be removed from CRAN due to the notes below. I have fixed two warnings detect locally when cloning the master branch. This is my first PR, so apologies for any issues with it. I would like to see the package back on CRAN, or understand if there are no plans to maintain it in the future.

----

Version: 0.0.1
Check: HTML version of manual
Result: NOTE
    Found the following HTML validation problems:
    powerjoin-package.html:23:4: Warning: <img> attribute "align" not allowed for HTML5
Flavors: [r-devel-linux-x86_64-debian-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/powerjoin-00check.html), [r-devel-linux-x86_64-debian-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/powerjoin-00check.html), [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/powerjoin-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/powerjoin-00check.html), [r-devel-windows-x86_64](https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/powerjoin-00check.html)

Version: 0.0.1
Check: dependencies in R code
Result: NOTE
    Namespaces in Imports field not imported from:
     ‘generics’ ‘lifecycle’ ‘magrittr’
     All declared Imports should be used.
Flavors: [r-devel-linux-x86_64-fedora-clang](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/powerjoin-00check.html), [r-devel-linux-x86_64-fedora-gcc](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-gcc/powerjoin-00check.html), [r-release-macos-arm64](https://www.r-project.org/nosvn/R.check/r-release-macos-arm64/powerjoin-00check.html), [r-release-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-release-macos-x86_64/powerjoin-00check.html), [r-oldrel-macos-arm64](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-arm64/powerjoin-00check.html), [r-oldrel-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-x86_64/powerjoin-00check.html)